### PR TITLE
Add some notes for OpenAPI

### DIFF
--- a/spring-boot-modules/spring-boot-libraries-2/pom.xml
+++ b/spring-boot-modules/spring-boot-libraries-2/pom.xml
@@ -93,6 +93,7 @@
                             <inputSpec>
                                 ${project.basedir}/src/main/resources/petstore.yml
                             </inputSpec>
+                            <!-- https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/spring.md -->
                             <generatorName>spring</generatorName>
                             <!-- This is the Java package base on which the generated files will
                             be located -->

--- a/spring-boot-modules/spring-boot-libraries-2/pom.xml
+++ b/spring-boot-modules/spring-boot-libraries-2/pom.xml
@@ -31,6 +31,7 @@
             <version>${jobrunr.version}</version>
         </dependency>
         <!-- openapi -->
+        <!-- There is only one dependency related to OpenAPI -->
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>openapi-generator</artifactId>
@@ -76,25 +77,35 @@
 
     <build>
         <plugins>
+            <!-- This is the plugin for handling the generation of Open API -->
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <version>${openapi-generator.version}</version>
                 <executions>
                     <execution>
+                        <!-- binding to the phase -->
                         <goals>
                             <goal>generate</goal>
                         </goals>
                         <configuration>
+                            <!-- Here we point to the Open API spec -->
                             <inputSpec>
                                 ${project.basedir}/src/main/resources/petstore.yml
                             </inputSpec>
                             <generatorName>spring</generatorName>
+                            <!-- This is the Java package base on which the generated files will
+                            be located -->
                             <apiPackage>com.baeldung.openapi.api</apiPackage>
+                            <!-- Model classes are also generated -->
                             <modelPackage>com.baeldung.openapi.model</modelPackage>
+                            <!-- TODO why do we need this? -->
                             <supportingFilesToGenerate>
                                 ApiUtil.java
                             </supportingFilesToGenerate>
+                            <!--
+                            we're asking to create an interface that can be implemented as a customized @Service class.
+                            -->
                             <configOptions>
                                 <delegatePattern>true</delegatePattern>
                             </configOptions>

--- a/spring-boot-modules/spring-boot-libraries-2/src/main/resources/petstore.yml
+++ b/spring-boot-modules/spring-boot-libraries-2/src/main/resources/petstore.yml
@@ -1,4 +1,5 @@
 # Here we have the Open API specification
+# How do we generate the documentation??
 openapi: "3.0.0"
 info:
   version: 1.0.0
@@ -87,6 +88,7 @@ paths:
 components:
   schemas:
     # Here is how we define the Pet object
+    # This file will be super huge if we put all the objects there, but I think this pb can be solved later on.
     Pet:
       type: object
       required:

--- a/spring-boot-modules/spring-boot-libraries-2/src/main/resources/petstore.yml
+++ b/spring-boot-modules/spring-boot-libraries-2/src/main/resources/petstore.yml
@@ -8,8 +8,12 @@ info:
 servers:
   - url: http://localhost:8080/
 paths:
+  # The generated class PetsApi.java is located in:
+  # target/generated-sources/openapi/src/main/java/com/baeldung/openapi/api/PetsApi.java
+  #
+  # However the generated file is not a standard JAX-RS resource but Spring resource.
   /pets:
-    get:
+    get: # method GET
       summary: List all pets
       operationId: listPets
       tags:
@@ -82,6 +86,7 @@ paths:
                 $ref: "#/components/schemas/Error"
 components:
   schemas:
+    # Here is how we define the Pet object
     Pet:
       type: object
       required:

--- a/spring-boot-modules/spring-boot-libraries-2/src/main/resources/petstore.yml
+++ b/spring-boot-modules/spring-boot-libraries-2/src/main/resources/petstore.yml
@@ -1,3 +1,4 @@
+# Here we have the Open API specification
 openapi: "3.0.0"
 info:
   version: 1.0.0


### PR DESCRIPTION
## Overview

Here are some personal notes for learning Open API.

https://www.baeldung.com/java-openapi-generator-server

## Open API Spec

Here is the spec for the API that we want to build:

```
spring-boot-modules/spring-boot-libraries-2/src/main/resources/petstore.yml
```

It consists of

- The paths that will be generated by the Open API and the underlying information
- The schemas (models) used by the API, including normal models and error models

## Open API Generator

Here we use the Maven Open API Generator plugin ([openapi-generator-maven-plugin](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md)) to generate the source code in Java. It exposes parameters to allow user to customize the generation, such as the location of the Open API specification (YAML), the generator used (spring), the API package, the model package, utility, and additional configuration options.

Find the documentation using the following pattern:

```
https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/{GENERATOR}.md
```

For example,

* https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/spring.md
* https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/go.md Go client
* https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/jaxrs-spec.md JAX-RS spec

what is `supportingFilesToGenerate`?

## Generated Files

The classes are generated in:
spring-boot-modules/spring-boot-libraries-2/target/generated-sources/openapi/src/main/java/com/baeldung/openapi

which is under the `target/generated-sources`, so it's not committed to the Git repository as `target` is ignored.

```
➜  tutorials git:(openapi u=) tree spring-boot-modules/spring-boot-libraries-2/target/generated-sources/openapi/src/main/java/com/baeldung/openapi
spring-boot-modules/spring-boot-libraries-2/target/generated-sources/openapi/src/main/java/com/baeldung/openapi
├── api
│   ├── ApiUtil.java
│   ├── PetsApi.java
│   ├── PetsApiController.java
│   └── PetsApiDelegate.java
└── model
    ├── Error.java
    └── Pet.java

2 directories, 6 files
```

TODO commit source code

## Implementation

TODO delegation?

## Jackson

TODO: Jackson annotation, cases (snake-case, camel-case, ...?)

## Backward Compatibility

Backward compatibility and versioning.

## Observability

TODO How to add additional annotations?

## Testing

## Documentation

## Model Generation

TODO Can I choose style about the model generation, such as Immutables or AutoValue rather than POJOs?

## Delegation

https://stackoverflow.com/questions/66294655/significance-of-delegate-design-pattern-in-swagger-generated-code

## References

- https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md
- https://github.com/OpenAPITools/openapi-generator/tree/master/samples/server/petstore/jaxrs-jersey